### PR TITLE
Add broker publish functions to plugin interface. Add client_id to acl and unpwd checks. Update example.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosquitto-plugin"
-version = "0.1.1"
+version = "1.0.0"
 authors = ["Kristoffer Ödmark <kristoffer.odmark90@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/example-acl/Cargo.toml
+++ b/example-acl/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-mosquitto-plugin = { path = "../../mosquitto-plugin" }
+mosquitto-plugin = { path = "../." }
 
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,18 @@
 pub mod mosquitto_dev;
 
-pub use mosquitto_dev::{mosquitto, mosquitto_acl_msg, mosquitto_opt};
+pub use mosquitto_dev::{
+    mosquitto, mosquitto_acl_msg, mosquitto_broker_publish, mosquitto_opt, mosquitto_property,
+    mqtt5__property,
+};
 
 use std::collections::HashMap;
 use std::ffi::CStr;
+use std::ffi::CString;
+use std::fmt;
 pub mod dynlib;
 pub use dynlib::*;
 pub use libc;
+use libc::c_void;
 
 pub fn __own_string(ch: *mut std::os::raw::c_char) -> String {
     if !ch.is_null() {
@@ -46,24 +52,60 @@ pub fn __from_ptr_and_size<'a>(opts: *mut mosquitto_opt, count: usize) -> Mosqui
     map
 }
 
-// #[repr(C)]
-// #[derive(Debug, Copy, Clone)]
-// pub enum AccessLevel {
-//     Subscribe = 0,
-//     Read = 1,
-//     Write = 2,
-//     None = 3,
-// }
-// impl Into<AccessLevel> for i32 {
-//     fn into(self) -> AccessLevel {
-//         match self {
-//             0 => AccessLevel::Subscribe,
-//             1 => AccessLevel::Read,
-//             2 => AccessLevel::Write,
-//             _ => AccessLevel::None,
-//         }
-//     }
-// }
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum AccessLevel {
+    None = 0,
+    Read = 1,
+    Write = 2,
+    Subscribe = 4,
+    Unsubscribe = 8,
+    Unknown,
+}
+
+impl Into<AccessLevel> for i32 {
+    fn into(self) -> AccessLevel {
+        match self {
+            0 => AccessLevel::None,
+            1 => AccessLevel::Read,
+            2 => AccessLevel::Write,
+            4 => AccessLevel::Subscribe,
+            8 => AccessLevel::Unsubscribe,
+            _ => AccessLevel::Unknown,
+        }
+    }
+}
+
+impl std::fmt::Display for AccessLevel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub enum AclCheckAccessLevel {
+    Read = 1,
+    Write = 2,
+    Subscribe = 4,
+}
+
+impl std::fmt::Display for AclCheckAccessLevel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl Into<Option<AclCheckAccessLevel>> for AccessLevel {
+    fn into(self) -> Option<AclCheckAccessLevel> {
+        match self {
+            AccessLevel::Read => Some(AclCheckAccessLevel::Read),
+            AccessLevel::Write => Some(AclCheckAccessLevel::Write),
+            AccessLevel::Subscribe => Some(AclCheckAccessLevel::Subscribe),
+            _ => None,
+        }
+    }
+}
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -140,6 +182,21 @@ pub struct MosquittoAclMessage<'a> {
     pub retain: bool,
 }
 
+pub enum QOS {
+    AtMostOnce,
+    AtLeastOnce,
+    ExactlyOnce,
+}
+impl QOS {
+    fn to_i32(&self) -> i32 {
+        match self {
+            QOS::AtMostOnce => 0,
+            QOS::AtLeastOnce => 1,
+            QOS::ExactlyOnce => 2,
+        }
+    }
+}
+
 pub trait MosquittoPlugin {
     /// This will be run once on every startup, or load, and will allocate the structure, to be
     /// reconstructed in other calls to the plugin.
@@ -149,13 +206,117 @@ pub trait MosquittoPlugin {
 
     /// Access level checks, default implementation always returns success
     #[allow(unused)]
-    fn acl_check(&mut self, acl: i32, msg: MosquittoAclMessage) -> Result<Success, Error> {
+    fn acl_check(
+        &mut self,
+        client_id: &str,
+        acl: AclCheckAccessLevel,
+        msg: MosquittoAclMessage,
+    ) -> Result<Success, Error> {
         Ok(Success)
     }
     #[allow(unused)]
     /// Username and password checks, default implementation always returns success
-    fn username_password(&mut self, username: &str, password: &str) -> Result<Success, Error> {
+    fn username_password(
+        &mut self,
+        client_id: &str,
+        username: Option<&str>,
+        password: Option<&str>,
+    ) -> Result<Success, Error> {
         Ok(Success)
+    }
+    #[allow(unused)]
+    /// Broadcast a message from the broker
+    /// If called in a username and password check the connecting client will not get the message
+    /// Use the broker_publish_to_client combined with this if you want to send to all clients including the one that is connecting
+    fn broker_broadcast_publish(
+        &mut self,
+        topic: &str,
+        payload: &[u8],
+        qos: QOS,
+        retain: bool,
+    ) -> Result<Success, Error> {
+        let cstr = &CString::new(topic).expect("no cstring for u");
+        let bytes = cstr.as_bytes_with_nul();
+        let topic = bytes.as_ptr();
+
+        let mut nullptr: *const c_void = std::ptr::null();
+        let properties: *mut mosquitto_property = std::ptr::null_mut();
+
+        // let payload: *mut c_void = std::ptr::null_mut(); // payload bytes, non-null if payload length > 0, must be heap allocated
+        let payload_len = payload.len();
+        let payload: *const c_void = Box::new(payload).as_ptr() as *const c_void; // payload bytes, non-null if payload length > 0, must be heap allocated
+
+        unsafe {
+            let c_payload: *mut c_void =
+                libc::malloc(std::mem::size_of::<u8>() * payload_len) as *mut c_void;
+            payload.copy_to(c_payload, payload_len);
+            /**
+             * https://mosquitto.org/api2/files/mosquitto_broker-h.html#mosquitto_broker_publish
+             * maybe want to switch to mosquitto_broker_publish to maintain ownership over
+             * payload memory.
+             * "payload	payload bytes.  If payloadlen > 0 this must not be NULL.  Must be allocated on the heap.  Will be freed by mosquitto after use if the function returns success."
+             * What happens if it is not successfull? Do i need to free the memory myself? This is a leak if if i front free memory  in all cases except 0 (Success) below?
+             */
+            let res = mosquitto_broker_publish(
+                nullptr as *const i8, // client id to send to, null = all clients
+                topic as *const i8,
+                payload_len as i32, // payload length in bytes, 0 for empty payload
+                c_payload, // payload bytes, non-null if payload length > 0, must be heap allocated
+                qos.to_i32(), // qos
+                retain,    // retain
+                properties, //mqtt5 properties
+            );
+            match res {
+                0 => Ok(Success),
+                1 => Err(Error::NoMem),
+                3 => Err(Error::Inval),
+                default => Err(Error::Unknown),
+            }
+        }
+    }
+    #[allow(unused)]
+    /// To be called from implementations the plugin when
+    /// a plugin wants to publish to a specific client.
+    fn broker_publish_to_client(
+        &mut self,
+        client_id: &str,
+        topic: &str,
+        payload: &[u8],
+        qos: QOS,
+        retain: bool,
+    ) -> Result<Success, Error> {
+        let cstr = &CString::new(client_id).expect("no cstring for u");
+        let bytes = cstr.as_bytes_with_nul();
+        let client_id = bytes.as_ptr();
+
+        let cstr = &CString::new(topic).expect("no cstring for u");
+        let bytes = cstr.as_bytes_with_nul();
+        let topic = bytes.as_ptr();
+
+        let payload_len = payload.len();
+        let payload: *const c_void = Box::new(payload).as_ptr() as *const c_void;
+
+        unsafe {
+            let c_payload: *mut c_void =
+                libc::malloc(std::mem::size_of::<u8>() * payload_len) as *mut c_void;
+            payload.copy_to(c_payload, payload_len);
+
+            let res = mosquitto_broker_publish(
+                client_id as *const i8, // client id to send to, null = all clients
+                topic as *const i8,     // topic to publish on
+                payload_len as i32,     // payload length in bytes, 0 for empty payload
+                c_payload, // payload bytes, non-null if payload length > 0, must be heap allocated
+                qos.to_i32(), // qos
+                retain,    // retain
+                std::ptr::null_mut(), //mqtt5 properties
+            );
+            match res {
+                0 => Ok(Success),
+                1 => Err(Error::NoMem),
+                3 => Err(Error::Inval),
+                default => Err(Error::Unknown),
+            }
+        }
     }
 }
 

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,1 +1,2 @@
+#include <mosquitto_broker.h>
 #include <mosquitto_plugin.h>


### PR DESCRIPTION
Hey, these should probably have been two PRs. But that didn't happen.

bingen now also generates bindings for mosquitto_broker.h to provide
mosquitto_broker_publish and mosquitto_client_id functions.
Extend existing MosquittoPlugin username_password and acl_check with
client_id.
Finish implementing AccessLevel and add more restricted
AclCheckAccessLevel enum to hand to acl_check function.