### PR TITLE
Bindgen improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ description = "A simple way to create plugins for mosquitto, using rust code"
 libc = "0.2"
 
 [build-dependencies]
-bindgen = "0.58"
+bindgen = { version = "0.59", default-features = false, features = ["runtime"] }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # Mosquitto Plugin
 
-A simple way to generate ACL and PASSWORD plugins for usage with the mosquitto broker.
+A simple way to generate ACL and PASSWORD plugins for usage with the mosquitto
+broker.
 
-requires that mosquitto_plugin.h mosquitto.h files are installed on the system, on linux systems
-this is usually achieved through the mosquitto-dev packages. Not tested on windows
+Requires that mosquitto_plugin.h mosquitto.h files are installed on the system,
+on linux systems this is usually achieved through the mosquitto-dev packages.
+Not tested on windows.
+
+To pass additional (clang) arguments to the clang invocation from `bindgen`, set
+`MOSQUITTO_PLUGIN_CLANG_EXTRA_ARGS` for e.g a special search path for the
+mosquitto headers: "-I ../mosquitto-2.0.4/include".
 
 The optional functions are not implemented here.
 
@@ -17,4 +23,4 @@ The optional functions are not implemented here.
 
 ## Example usage
 
-There is an example usage in the github repo under "example-acl" folder
+There is an example usage in the github repo under "example-acl" folder.

--- a/build.rs
+++ b/build.rs
@@ -3,14 +3,19 @@ extern crate bindgen;
 use std::env;
 use std::path::PathBuf;
 
+// Clang extra args env variable name
+const MOSQUITTO_PLUGIN_CLANG_EXTRA_ARGS: &str = "MOSQUITTO_PLUGIN_CLANG_EXTRA_ARGS";
+
 fn main() {
     // Tell cargo to invalidate the built crate whenever the wrapper changes
     println!("cargo:rerun-if-changed=wrapper.h");
+    // Tell cargo to invalidate the built crate whenever the extra args variable changes
+    println!("cargo:rerun-if-env-changed={}", MOSQUITTO_PLUGIN_CLANG_EXTRA_ARGS);
 
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
     // the resulting bindings.
-    let bindings = bindgen::Builder::default()
+    let builder = bindgen::Builder::default()
         // The input header we would like to generate
         // bindings for.
         .header("wrapper.h")
@@ -22,7 +27,16 @@ fn main() {
         .allowlist_var("MOSQ_.*")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks));
+
+    // If the clang extra arguments variable is set, add the arguments
+    let builder = if let Ok(args) = env::var(MOSQUITTO_PLUGIN_CLANG_EXTRA_ARGS) {
+        builder.clang_args(args.split_whitespace())
+    } else {
+        builder
+    };
+
+    let bindings = builder
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.

--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,12 @@ fn main() {
         // The input header we would like to generate
         // bindings for.
         .header("wrapper.h")
+        // Filter functions with mosquitto_.*
+        .allowlist_function("mosquitto_.*")
+        // Filter types with mosquitto_.*
+        .allowlist_type("mosquitto_.*")
+        // Filter variables with MOSQ_.*
+        .allowlist_var("MOSQ_.*")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))


### PR DESCRIPTION
Some improvements on the `bindgen` integration:
 
* Bump bindgen and reduce used feature set
* Filter the types and functions from the mosquito headers to omit system stuff
* Add `MOSQUITTO_PLUGIN_CLANG_EXTRA_ARGS` to allow the injections of extra clang arguments which could be needed for e.g cross compile scenarios.