### PR TITLE
Add basic GH actions workflow and fix clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install mosquitto-dev
+        run: sudo add-apt-repository -y ppa:mosquitto-dev/mosquitto-ppa && sudo apt-get install -y mosquitto-dev
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install mosquitto-dev
+        run: sudo add-apt-repository -y ppa:mosquitto-dev/mosquitto-ppa && sudo apt-get install -y mosquitto-dev
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install mosquitto-dev
+        run: sudo add-apt-repository -y ppa:mosquitto-dev/mosquitto-ppa && sudo apt-get install -y mosquitto-dev
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/TotalKrill/mosquitto_plugin/workflows/ci/badge.svg)](https://github.com/TotalKrill/mosquitto_plugin/actions)
+
 # Mosquitto Plugin
 
 A simple way to generate ACL and PASSWORD plugins for usage with the mosquitto broker.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,9 @@ pub enum AccessLevel {
     Unknown,
 }
 
-impl Into<AccessLevel> for i32 {
-    fn into(self) -> AccessLevel {
-        match self {
+impl From<i32> for AccessLevel {
+    fn from(level: i32) -> AccessLevel {
+        match level {
             0 => AccessLevel::None,
             1 => AccessLevel::Read,
             2 => AccessLevel::Write,
@@ -91,9 +91,9 @@ impl std::fmt::Display for AclCheckAccessLevel {
     }
 }
 
-impl Into<Option<AclCheckAccessLevel>> for AccessLevel {
-    fn into(self) -> Option<AclCheckAccessLevel> {
-        match self {
+impl From<AccessLevel> for Option<AclCheckAccessLevel> {
+    fn from(level: AccessLevel) -> Option<AclCheckAccessLevel> {
+        match level {
             AccessLevel::Read => Some(AclCheckAccessLevel::Read),
             AccessLevel::Write => Some(AclCheckAccessLevel::Write),
             AccessLevel::Subscribe => Some(AclCheckAccessLevel::Subscribe),
@@ -138,17 +138,16 @@ pub enum Error {
     OCSP = 26,
 }
 
-impl Into<i32> for Error {
-    fn into(self) -> i32 {
-        self as i32
+impl From<Error> for i32 {
+    fn from(e: Error) -> i32 {
+        e as i32
     }
 }
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Success;
 
-impl Into<i32> for Success {
-    fn into(self) -> i32 {
+impl From<Success> for i32 {
+    fn from(_: Success) -> i32 {
         0
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,7 +303,10 @@ impl MosquittoClientContext for MosquittoClient {
                 3 => MosquittoClientProtocolVersion::V3,
                 4 => MosquittoClientProtocolVersion::V4,
                 5 => MosquittoClientProtocolVersion::V5,
-                _ => panic!("invalid mosquitto client protocol version returned from mosquitto_client_protocol_version. {}", protocol_version)
+                _ => panic!(
+                    "invalid mosquitto client protocol version returned from mosquitto_client_protocol_version. {}",
+                    protocol_version
+                ),
             }
         }
     }


### PR DESCRIPTION
Fix trivial clippy warnings and a basic GH actions workflow with `fmt`, `check`, `test` and `clippy`. Add a CI status badge to the readme.