### PR TITLE
Wrap mosquitto_log_printf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosquitto-plugin"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Kristoffer Ödmark <kristoffer.odmark90@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/examples/basic-auth.rs
+++ b/examples/basic-auth.rs
@@ -35,7 +35,7 @@ impl MosquittoPlugin for Test {
         p: Option<&str>,
     ) -> Result<Success, Error> {
         let client_id = client.get_id().unwrap_or_else(|| "unknown".into());
-        println!("USERNAME_PASSWORD({}) {:?} - {:?}", client_id, u, p);
+        mosquitto_debug!("USERNAME_PASSWORD({}) {:?} - {:?}", client_id, u, p);
         if u.is_none() || p.is_none() {
             return Err(Error::Auth);
         }
@@ -61,7 +61,7 @@ impl MosquittoPlugin for Test {
             )?;
             Ok(Success)
         } else {
-            println!("USERNAME_PASSWORD failed for {}", client_id);
+            mosquitto_warn!("USERNAME_PASSWORD failed for {}", client_id);
             // Snitch to all other clients what a bad client that was.
             mosquitto_calls::publish_broadcast(
                 "snitcheroo",
@@ -79,9 +79,9 @@ impl MosquittoPlugin for Test {
         level: AclCheckAccessLevel,
         msg: MosquittoMessage,
     ) -> Result<Success, mosquitto_plugin::Error> {
-        println!("allowed topic: {}", self.s);
-        println!("topic: {}", msg.topic);
-        println!("level requested: {}", level);
+        mosquitto_debug!("allowed topic: {}", self.s);
+        mosquitto_debug!("topic: {}", msg.topic);
+        mosquitto_debug!("level requested: {}", level);
 
         // only the topic provided in the mosquitto.conf by the value auth_opt_topic <value> is
         // allowed, errors will not be reported to the clients though, they will only not be able
@@ -94,14 +94,14 @@ impl MosquittoPlugin for Test {
     }
 
     fn on_disconnect(&mut self, client: &dyn MosquittoClientContext, _reason: i32) {
-        println!(
+        mosquitto_info!(
             "Plugin on_disconnect, Client {:?} is disconnecting",
             client.get_id()
         );
     }
 
     fn on_message(&mut self, client: &dyn MosquittoClientContext, message: MosquittoMessage) {
-        println!(
+        mosquitto_info!(
             "Plugin on_message: client {:?}: Topic: {}, Payload: {:?}",
             client.get_id(),
             message.topic,

--- a/examples/extended-auth.rs
+++ b/examples/extended-auth.rs
@@ -20,7 +20,7 @@ impl MosquittoPlugin for AuthPlugin {
     }
 
     fn on_disconnect(&mut self, client: &dyn MosquittoClientContext, _reason: i32) {
-        println!(
+        mosquitto_info!(
             "Plugin on_disconnect, Client {:?} is disconnecting",
             client.get_id()
         );
@@ -33,7 +33,7 @@ impl MosquittoPlugin for AuthPlugin {
         method: Option<&str>,
         data: Option<&[u8]>,
     ) -> Result<Success, Error> {
-        println!(
+        mosquitto_info!(
             "Plugin on_auth_start, Client {:?} with method {:?} and data {:?}",
             client.get_id(),
             method,
@@ -51,23 +51,26 @@ impl MosquittoPlugin for AuthPlugin {
         data: Option<&[u8]>,
     ) -> Result<Success, Error> {
         let client_id = client.get_id().ok_or(Error::Inval)?;
-        println!(
+        mosquitto_info!(
             "Plugin on_auth_continue, Client {} with method {:?} and data {:?}",
-            client_id, method, data
+            client_id,
+            method,
+            data
         );
 
         // If client replies with "hello broker" we're fine - otherwise greet again.
         if let Some(data) = data {
             if data == HELLO_BROKER.as_bytes() {
-                println!(
+                mosquitto_info!(
                     "Plugin on_auth_continue, Client {} authenticated",
                     client_id
                 );
                 Ok(Success)
             } else {
-                println!(
+                mosquitto_warn!(
                     "Plugin on_auth_continue, Client {} failed to authenticate. Expected \"{}\"",
-                    client_id, HELLO_BROKER,
+                    client_id,
+                    HELLO_BROKER,
                 );
                 Err(Error::AuthContinue(HELLO_CLIENT.as_bytes().to_vec()))
             }

--- a/src/dynlib.rs
+++ b/src/dynlib.rs
@@ -105,7 +105,7 @@ macro_rules! create_dynamic_library {
             let access_level = if let Some(level) = access_level.into() {
                 level
             } else {
-                println!("Unexpected access level for acl check. {:?}", access_level);
+                mosquitto_warn!("Unexpected access level for acl check. {:?}", access_level);
                 return Error::Unknown.into();
             };
 
@@ -432,7 +432,7 @@ macro_rules! create_dynamic_library {
                 "on disconnect_trampoline user_data is null"
             );
             let user_data: &mut InternalUserData = unsafe {
-                // println!("Got user data: {:?}", user_data);
+                // mosquitto_debug!("Got user data: {:?}", user_data);
                 &mut *(user_data as *mut InternalUserData)
             };
 
@@ -458,11 +458,11 @@ macro_rules! create_dynamic_library {
             opt_count: c_int,
         ) -> c_int {
             let opts = __from_ptr_and_size(opts, opt_count as _);
-            println!("mosquitto_plugin_init {:?}", opts);
+            mosquitto_debug!("mosquitto_plugin_init {:?}", opts);
 
             let instance: $t = <$t>::init(opts);
             let instance = instance;
-            println!("external_user_data addr {:?}", instance);
+            mosquitto_debug!("external_user_data addr {:?}", instance);
             let internal_user_data = InternalUserData {
                 identifier,
                 external_user_data: instance,
@@ -591,7 +591,7 @@ macro_rules! create_dynamic_library {
                         .to_str()
                         .expect("plugin identifier is null at cleanup")
                 };
-                println!("cleaning up plugin: {}", identifier);
+                mosquitto_debug!("cleaning up plugin: {}", identifier);
             }
             drop(unsafe { Box::from_raw(user_data as *mut InternalUserData) });
 


### PR DESCRIPTION
Expose the mosquitto logging subsystem by exposing `mosquitto_log` along with `log` crate style macros (`mosquitto_log`, `mosquitto_info`...).