### PR TITLE
Fix mosquitto_log call

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosquitto-plugin"
-version = "2.1.1"
+version = "2.1.2"
 authors = ["Kristoffer Ödmark <kristoffer.odmark90@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/src/mosquitto_calls.rs
+++ b/src/mosquitto_calls.rs
@@ -125,7 +125,13 @@ pub enum LogLevel {
 /// Send a log message on `level` to the mosquitto logging subsystem.
 pub fn mosquitto_log(level: LogLevel, message: &str) {
     let message = CString::new(message).expect("invalid log message: contains a nul byte");
-    unsafe { mosquitto_log_printf(level as i32, message.as_ptr()) }
+    unsafe {
+        mosquitto_log_printf(
+            level as i32,
+            "%s\0".as_ptr() as *const c_char,
+            message.as_ptr(),
+        )
+    }
 }
 /// Logs a message at the debug level into the mosquitto logging subsystem.
 ///


### PR DESCRIPTION
Do not use the log message as first argument to mosquitto_log_printf because it is used as format string. Use a const "%s" format string and add message as parameter. This avoid UB when message contains %.